### PR TITLE
Namespacing and API auth

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -15,4 +15,5 @@ gutsy:
     gem_version: 0.2.0                      # Gem version
     versions:
       - name: v1
+        resource_namespace: features          # (optional) additional URL namespacing
         schema_path: docs/api/v1/schema.json

--- a/lib/gutsy/generator/api_version_state.rb
+++ b/lib/gutsy/generator/api_version_state.rb
@@ -3,13 +3,14 @@ module Gutsy
     class ApiVersionState
       extend Forwardable
 
-      attr_reader :name, :schema, :schema_path
+      attr_reader :name, :schema, :schema_path, :resource_namespace
 
       def_delegators :gem_state, :gem_name_pascal, :gem_name_snake, :app_name, :base_url
 
       def initialize(api_version_config, gem_state)
         @name = api_version_config[:name]
         @schema_path = api_version_config[:schema_path]
+        @resource_namespace = api_version_config[:resource_namespace]
         @gem_state = gem_state
       end
 

--- a/lib/gutsy/generator/heroics.rb
+++ b/lib/gutsy/generator/heroics.rb
@@ -27,7 +27,15 @@ module Gutsy
       end
 
       def api_url
-        @api_url ||= "#{api_version_state.base_url}/api/#{api_version_state.name.downcase}"
+        @api_url ||= "#{api_version_state.base_url}/api/#{resource_namespace}#{api_version_state.name.downcase}"
+      end
+
+      def resource_namespace
+        if api_version_state.resource_namespace
+          "#{api_version_state.resource_namespace}/"
+        else
+          ''
+        end
       end
 
       def client_output_path

--- a/templates/app_client/README.md.erb
+++ b/templates/app_client/README.md.erb
@@ -23,8 +23,8 @@ gem '<%= gem_name_snake %>', '~> <%= gem_version %>'
   ```ruby
   <%= gem_name_pascal %>.configure do |config|
     config.base_url   = "<%= base_url %>"
-    config.api_key    = "i-am-api-user"         # HTTP Basic Auth User
-    config.api_secret = "very-secret-sssshhh"   # HTTP Basic Auth Pass
+    config.api_key    = "i-am-api-user"
+    config.api_secret = "very-secret-sssshhh"
     # or OAuth access token
     # config.access_token = ENV['<%= gem_name_snake.upcase %>_ACCESS_TOKEN']
   end

--- a/templates/app_client/lib/app_client.rb.erb
+++ b/templates/app_client/lib/app_client.rb.erb
@@ -50,7 +50,7 @@ module <%= gem_name_pascal %>
     end
 
     def api_version=(version)
-      options[:url] = "#{base_url}/api/#{version}"
+      options[:url] = "#{base_url}/api/#{resource_namespace}#{version}"
       @api_version = version
     end
 
@@ -59,8 +59,12 @@ module <%= gem_name_pascal %>
     end
 
     def base_url=(url)
-      options[:url] = "#{url}/api/#{api_version}"
+      options[:url] = "#{url}/api/#{resource_namespace}#{api_version}"
       @base_url = url
+    end
+
+    def resource_namespace
+      '<%= "#{api_versions.first.resource_namespace}/" if api_versions.first.resource_namespace %>'
     end
   end
 end

--- a/templates/app_client/lib/app_client/api_version/adapter.rb.erb
+++ b/templates/app_client/lib/app_client/api_version/adapter.rb.erb
@@ -28,7 +28,10 @@ module <%= gem_name_pascal %>
             config.adapter_factory.connect_oauth(access_token, options)
           elsif api_key && api_secret
             config.adapter_factory.connect(api_secret, options.merge!({
-              user: config.api_key
+              default_headers: {
+                'X-API-KEY' => config.api_key,
+                'X-API-SECRET' => config.api_secret,
+              }
             }))
           else
             raise "access_token or API key & secret are required to connect to <%= app_name %> <%= module_name %> API"


### PR DESCRIPTION
* Allow additional URL namespacing: 62798bd
  * is `resource_namespace` the right name?
* Use headers for API key auth: f5cd293
