### PR TITLE
Allow multiple clients with runtime config

### DIFF
--- a/templates/app_client/lib/app_client.rb.erb
+++ b/templates/app_client/lib/app_client.rb.erb
@@ -39,35 +39,41 @@ module <%= gem_name_pascal %>
   class Configuration
     attr_accessor :access_token, :api_key, :api_secret,
                   :base_url, :options,
-                  :adapter_factory, :api_version
+                  :adapter_factory, :api_version, :api_version_name
 
     def options
       @options ||= {}
     end
 
     def api_version
-      @api_version = options[:api_version] || '<%= api_versions.first.name %>'
+      @api_version = if options[:api_version_name] && options[:resource_namespace]
+        OpenStruct.new(name: options[:api_version_name], resource_namespace: options[:resource_namespace])
+      else
+<% if api_versions.first -%>
+        OpenStruct.new(name: '<%= "#{api_versions.first.name}" -%>', resource_namespace: '<%= "#{api_versions.first.resource_namespace}" -%>')
+<% else -%>
+        OpenStruct.new(name: '', resource_namespace: '')
+<% end -%>
+      end
     end
 
-    def api_version=(version)
-      options[:url] = "#{base_url}/api/#{resource_namespace}#{version}"
-      @api_version = version
+    def api_version_name=(name)
+      options[:url]     = "#{base_url}/api/#{resource_namespace}#{name}"
+      @api_version_name = name
+      @api_version.name = name
     end
 
     def adapter_factory
-      version = options[:api_version] ? options[:api_version] : api_version
-      @adapter_factory = <%= gem_name_pascal %>.const_get("#{version.upcase}")::Adapters::Http
+      @adapter_factory = <%= gem_name_pascal %>.const_get("#{api_version.name.upcase}")::Adapters::Http
     end
 
     def base_url=(url)
-      options[:url] = "#{url}/api/#{resource_namespace}#{api_version}"
-      @base_url = url
+      options[:url] = "#{url}/api/#{resource_namespace}#{api_version.name}"
+      @base_url     = url
     end
 
     def resource_namespace
-<% if api_versions.first.resource_namespace -%>
-     options[:resource_namespace] || '<%= "#{api_versions.first.resource_namespace}/" %>'
-<% end -%>
+      api_version.resource_namespace
     end
   end
 end

--- a/templates/app_client/lib/app_client.rb.erb
+++ b/templates/app_client/lib/app_client.rb.erb
@@ -46,7 +46,7 @@ module <%= gem_name_pascal %>
     end
 
     def api_version
-      @api_version ||= '<%= api_versions.first.name %>'
+      @api_version = options[:api_version] || '<%= api_versions.first.name %>'
     end
 
     def api_version=(version)
@@ -55,7 +55,8 @@ module <%= gem_name_pascal %>
     end
 
     def adapter_factory
-      @adapter_factory ||= <%= gem_name_pascal %>.const_get("#{api_version.upcase}")::Adapters::Http
+      version = options[:api_version] ? options[:api_version] : api_version
+      @adapter_factory = <%= gem_name_pascal %>.const_get("#{version.upcase}")::Adapters::Http
     end
 
     def base_url=(url)
@@ -64,7 +65,9 @@ module <%= gem_name_pascal %>
     end
 
     def resource_namespace
-      '<%= "#{api_versions.first.resource_namespace}/" if api_versions.first.resource_namespace %>'
+<% if api_versions.first.resource_namespace -%>
+     options[:resource_namespace] || '<%= "#{api_versions.first.resource_namespace}/" %>'
+<% end -%>
     end
   end
 end

--- a/templates/app_client/lib/app_client/api_version/adapter.rb.erb
+++ b/templates/app_client/lib/app_client/api_version/adapter.rb.erb
@@ -18,7 +18,9 @@ module <%= gem_name_pascal %>
           access_token  ||= config.access_token
           api_key       ||= config.api_key
           api_secret    ||= config.api_secret
-          options         = config.options.merge!(options)
+
+          config.options.except!(:api_version, :resource_namespace)
+          options = config.options.merge!(options)
 
           # Workaround issue with some TLS setups (haproxy)
           # Prevents :443 being added to hostname for TLS


### PR DESCRIPTION
### Summary

Currently, gutsy generates clients with a shared global config `ChirpClient.configuration`, which sets the `api_version` and `resource_namespace`values to whatever API endpoint gets generated first. These values are used to fetch the client's http adapter and generate its url.

This pull allows you to pass in `api_version` and `resource_namespace` as options, so it returns the correct url and http adapter for the client.

You can use the generated defaults (first client wins) and change it to talk to another resource/api endpoint:
```ruby
ChirpClient.configure do |config|
  config.api_key = 'blah'
  config.api_secret = 'boo'
end

client = ChirpClient::V6::Note.new
client.list(derived_encounter_uid: "3b88f6701ef74adea1e1abc78688388b")

client = ChirpClient::V4::Patient.new(nil, options: { api_version: 'v4', resource_namespace: 'patients/' })
client.show(Patient.last.guid)
```
----------------------
Supports this card - https://trello.com/c/H2bEZcBO/523-8-talix-integration-outbound-export