### PR TITLE
Support multiple API versions

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -15,5 +15,5 @@ gutsy:
     gem_version: 0.2.0                      # Gem version
     versions:
       - name: v1
-        resource_url: api/features/v1       # (optional) for additional URL namespacing
+        namespace_path: api/features/v1     # (optional) for additional URL namespacing. Would default to `api/v1` in this example
         schema_path: docs/api/v1/schema.json

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -15,5 +15,5 @@ gutsy:
     gem_version: 0.2.0                      # Gem version
     versions:
       - name: v1
-        resource_namespace: features          # (optional) additional URL namespacing
+        resource_url: api/features/v1       # (optional) for additional URL namespacing
         schema_path: docs/api/v1/schema.json

--- a/lib/gutsy/generator/api_version_state.rb
+++ b/lib/gutsy/generator/api_version_state.rb
@@ -3,14 +3,14 @@ module Gutsy
     class ApiVersionState
       extend Forwardable
 
-      attr_reader :name, :schema, :schema_path, :resource_url
+      attr_reader :name, :schema, :schema_path, :namespace_path
 
       def_delegators :gem_state, :gem_name_pascal, :gem_name_snake, :app_name, :base_url
 
       def initialize(api_version_config, gem_state)
         @name = api_version_config[:name]
         @schema_path = api_version_config[:schema_path]
-        @resource_url = api_version_config[:resource_url] || "api/#{@name.downcase}"
+        @namespace_path = api_version_config[:namespace_path] || "api/#{@name.downcase}"
         @gem_state = gem_state
       end
 

--- a/lib/gutsy/generator/api_version_state.rb
+++ b/lib/gutsy/generator/api_version_state.rb
@@ -3,14 +3,14 @@ module Gutsy
     class ApiVersionState
       extend Forwardable
 
-      attr_reader :name, :schema, :schema_path, :resource_namespace
+      attr_reader :name, :schema, :schema_path, :resource_url
 
       def_delegators :gem_state, :gem_name_pascal, :gem_name_snake, :app_name, :base_url
 
       def initialize(api_version_config, gem_state)
         @name = api_version_config[:name]
         @schema_path = api_version_config[:schema_path]
-        @resource_namespace = api_version_config[:resource_namespace]
+        @resource_url = api_version_config[:resource_url] || "api/#{@name.downcase}"
         @gem_state = gem_state
       end
 

--- a/lib/gutsy/generator/heroics.rb
+++ b/lib/gutsy/generator/heroics.rb
@@ -27,15 +27,7 @@ module Gutsy
       end
 
       def api_url
-        @api_url ||= "#{api_version_state.base_url}/api/#{resource_namespace}#{api_version_state.name.downcase}"
-      end
-
-      def resource_namespace
-        if api_version_state.resource_namespace
-          "#{api_version_state.resource_namespace}/"
-        else
-          ''
-        end
+        @api_url ||= "#{api_version_state.base_url}/#{api_version_state.resource_url}"
       end
 
       def client_output_path

--- a/lib/gutsy/generator/heroics.rb
+++ b/lib/gutsy/generator/heroics.rb
@@ -27,7 +27,7 @@ module Gutsy
       end
 
       def api_url
-        @api_url ||= "#{api_version_state.base_url}/#{api_version_state.resource_url}"
+        @api_url ||= "#{api_version_state.base_url}/#{api_version_state.namespace_path}"
       end
 
       def client_output_path

--- a/templates/app_client/lib/app_client.rb.erb
+++ b/templates/app_client/lib/app_client.rb.erb
@@ -37,34 +37,6 @@ module <%= gem_name_pascal %>
   end
 
   class Configuration
-    attr_accessor :access_token, :api_key, :api_secret,
-                  :base_url, :options,
-                  :adapter_factory, :api_version
-
-    def options
-      @options ||= {}
-    end
-
-    def api_version
-      @api_version ||= '<%= api_versions.first.name %>'
-    end
-
-    def api_version=(version)
-      options[:url] = "#{base_url}/api/#{resource_namespace}#{version}"
-      @api_version = version
-    end
-
-    def adapter_factory
-      @adapter_factory ||= <%= gem_name_pascal %>.const_get("#{api_version.upcase}")::Adapters::Http
-    end
-
-    def base_url=(url)
-      options[:url] = "#{url}/api/#{resource_namespace}#{api_version}"
-      @base_url = url
-    end
-
-    def resource_namespace
-      '<%= "#{api_versions.first.resource_namespace}/" if api_versions.first.resource_namespace %>'
-    end
+    attr_accessor :access_token, :api_key, :api_secret, :base_url
   end
 end

--- a/templates/app_client/lib/app_client/api_version/adapter.rb.erb
+++ b/templates/app_client/lib/app_client/api_version/adapter.rb.erb
@@ -18,16 +18,18 @@ module <%= gem_name_pascal %>
           access_token  ||= config.access_token
           api_key       ||= config.api_key
           api_secret    ||= config.api_secret
-          options         = config.options.merge!(options)
+          url             = "#{config.base_url}/<%= resource_url %>"
 
           # Workaround issue with some TLS setups (haproxy)
           # Prevents :443 being added to hostname for TLS
           Excon.defaults[:omit_default_port] = true
 
+          options = { url: url }.merge(options)
+
           if access_token
-            config.adapter_factory.connect_oauth(access_token, options)
+            Adapters::Http.connect_oauth(access_token, options)
           elsif api_key && api_secret
-            config.adapter_factory.connect(api_secret, options.merge!({
+            Adapters::Http.connect(api_secret, options.merge!({
               user: config.api_key
             }))
           else

--- a/templates/app_client/lib/app_client/api_version/adapter.rb.erb
+++ b/templates/app_client/lib/app_client/api_version/adapter.rb.erb
@@ -18,7 +18,7 @@ module <%= gem_name_pascal %>
           access_token  ||= config.access_token
           api_key       ||= config.api_key
           api_secret    ||= config.api_secret
-          url             = "#{config.base_url}/<%= resource_url %>"
+          url             = "#{config.base_url}/<%= namespace_path %>"
 
           # Workaround issue with some TLS setups (haproxy)
           # Prevents :443 being added to hostname for TLS


### PR DESCRIPTION
Previously we were mutating the global config, which was causing config to
leak from one version to the next

Paired w/ @bfitch